### PR TITLE
Decoupled agent and streamlit logic

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,1 +1,1 @@
-from agents.agents import get_agent
+from agents.agents import get_agent, BaseAgent

--- a/agents/agents.py
+++ b/agents/agents.py
@@ -1,13 +1,115 @@
-from agents import comparison_geo_agent
-from agents import geo_agent
-from agents import agent_tool_selector
+from abc import ABC, abstractmethod
+
+from langchain_core.messages import HumanMessage
+from langgraph.graph.state import CompiledStateGraph
+import streamlit as st
+
+from agents import (
+    agent_tool_selector,
+    comparison_geo_agent,
+    geo_agent
+)
+from schemas.geometry import BoundingBox, PointMarker
+from utils.agent_utils import get_chat_history, pair_response_messages, store_run_messages
+
+class BaseAgent(ABC):
+    def __init__(self, name: str, graph: CompiledStateGraph):
+        self.name = name
+        self.graph = graph
+    
+    @abstractmethod
+    def run(self, prompt: str, bounding_box: BoundingBox, marker: PointMarker | None, config: dict):
+        pass
+    
+    @abstractmethod
+    def store_run_details(self, state: dict, config: dict):
+        pass
+
+class GeoAgent(BaseAgent):
+    def run(self, prompt: str, bounding_box: BoundingBox, marker: PointMarker | None, config: dict):
+        input = {
+            "messages": [HumanMessage(content=prompt)],
+            "chat_history": get_chat_history().messages,
+            "bounding_box": bounding_box,
+            "hotel_site_marker": marker
+        }
+        return self.graph.stream(
+            input=input,
+            config=config,
+            stream_mode="values",
+        )
+    
+    def store_run_details(self, state: dict, config: dict):
+        get_chat_history().add_messages(state["messages"])
+        last_message = state["messages"][-1]
+        last_message.run_id = config["run_id"]
+    
+class ComparisonGeoAgent(BaseAgent):
+    def run(self, prompt: str, bounding_box: BoundingBox, marker: PointMarker | None, config: dict):
+        bbox_text = f"The bounding box is defined by the following coordinates (lat1, lon1, lat2, lon2):\n" \
+        f"{bounding_box.to_string_latlon()}\n"
+
+        input = {
+            "messages": [HumanMessage(content=prompt)],
+            "chat_history": get_chat_history().messages,
+            "bounding_box": bounding_box,
+            "hotel_site_marker": marker,
+            "alternative_user_message": HumanMessage(content=bbox_text + prompt),
+            "alternative_history": get_chat_history(alternative=True).messages,
+        }
+        return self.graph.stream(
+            input=input,
+            config=config,
+            stream_mode="values",
+        )
+
+    def store_run_details(self, state: dict, config: dict):
+        store_run_messages(state["messages"], alternative=False)
+        
+        last_message = state["messages"][-1]
+        last_message.run_id = config["run_id"]
+        alternative = state.get("alternative_response", None)
+
+        if alternative is not None:
+            pair_response_messages(config["run_id"], last_message, alternative)
+            store_run_messages([state["alternative_user_message"], state["alternative_response"]], alternative=True)
+
+class AgentToolSelector(BaseAgent):
+    def run(self, prompt: str, bounding_box: BoundingBox, marker: PointMarker | None, config: dict):
+        bbox_text = f"The bounding box is defined by the following coordinates (lat1, lon1, lat2, lon2):\n" \
+        f"{bounding_box.to_string_latlon()}\n"
+
+        input = {
+            "messages": [HumanMessage(content=prompt)],
+            "chat_history": get_chat_history().messages,
+            "bounding_box": bounding_box,
+            "hotel_site_marker": marker,
+            "alternative_user_message": HumanMessage(content=bbox_text + prompt),
+            "alternative_history": get_chat_history(alternative=True).messages,
+        }
+        return self.graph.stream(
+            input=input,
+            config=config,
+            stream_mode="values",
+        )
+    
+    def store_run_details(self, state: dict, config: dict):
+        store_run_messages(state["messages"], alternative=False)
+        
+        last_message = state["messages"][-1]
+        last_message.run_id = config["run_id"]
+        alternative = state.get("alternative_response", None)
+
+        if alternative is not None:
+            pair_response_messages(config["run_id"], last_message, alternative)
+            store_run_messages([state["alternative_user_message"], state["alternative_response"]], alternative=True)
 
 def get_agent(name: str):
     if name == "geo":
-        return geo_agent.graph
+        return GeoAgent(name, geo_agent.graph)
     elif name == "comparison_geo":
-        return comparison_geo_agent.graph
+        return ComparisonGeoAgent(name, comparison_geo_agent.graph)
     elif name == "tool_selector_geo":
-        return agent_tool_selector.graph
+        return AgentToolSelector(name, agent_tool_selector.graph)
     else:
         raise ValueError(f"Unknown agent name: {name}")

--- a/agents/comparison_geo_agent.py
+++ b/agents/comparison_geo_agent.py
@@ -4,13 +4,11 @@ from langgraph.graph import START, END, StateGraph
 from langgraph.graph.message import add_messages
 from langgraph.prebuilt import ToolNode
 from typing_extensions import Annotated, TypedDict, Optional
-import streamlit as st
 
 from agents.prompts import SYSTEM_PROMPT_COMPARISON, get_current_timestamp
-from paths import PROJECT_ROOT
 from tools import get_all_tools
 from schemas.geometry import BoundingBox, PointMarker
-from utils.agent_utils import get_chat_history, get_llm
+from utils.agent_utils import get_llm
 
 class AgentState(TypedDict):
     """
@@ -18,14 +16,20 @@ class AgentState(TypedDict):
 
     Attributes:
         messages: List of current chat messages
+        chat_history: List of chat history messages
         bounding_box: Bounding box instance representing a geographical area of interest.
         hotel_site_marker: Coordinates of a potential hotel site marker.
+        alternative_user_message: User message for the alternative response
         alternative_response: Alternative model response generated without tools
+        alternative_history: Message history for the alternative response
     """
     messages: Annotated[list[AnyMessage], add_messages]
+    chat_history: list[AnyMessage]
     bounding_box: BoundingBox
     hotel_site_marker: PointMarker
+    alternative_user_message: Optional[str]
     alternative_response: Optional[AIMessage]
+    alternative_history: Optional[list[AnyMessage]]
 
 def should_continue(state: AgentState, config: RunnableConfig):
     msgs = state["messages"]
@@ -34,36 +38,20 @@ def should_continue(state: AgentState, config: RunnableConfig):
         if state.get("alternative_response", None) is None:
             return ["alternative", "tools"]
         return "tools"
-
-    get_chat_history().add_messages(msgs)
-    last_message.run_id = config["configurable"]["run_id"]
-    for m in msgs:
-        st.session_state.all_messages[m.id] = m
-    alternative = state.get("alternative_response", None)
-    if  alternative is not None:
-        last_message.alternative_id = alternative.id
-        alternative.alternative_id = last_message.id
-        alternative.run_id = config["configurable"]["run_id"]
-        st.session_state.all_messages[alternative.id] = alternative
     return END
 
 def call_model(state: AgentState, config: RunnableConfig):
     llm = get_llm(config["configurable"]["model_name"])
     llm_with_tools = llm.bind_tools(get_all_tools())
 
-    chat_history = get_chat_history()
-    msgs = [SystemMessage(content=SYSTEM_PROMPT_COMPARISON.format(timestamp=get_current_timestamp()))] + list(chat_history.messages) + state["messages"]
+    msgs = [SystemMessage(content=SYSTEM_PROMPT_COMPARISON.format(timestamp=get_current_timestamp()))] + state["chat_history"] + state["messages"]
     response = llm_with_tools.invoke(msgs)
     return {"messages": [response]}
 
 def call_without_tools(state: AgentState, config: RunnableConfig):
     llm = get_llm(config["configurable"]["model_name"])
 
-    bbox_text = f"The bounding box is defined by the following coordinates (lat1, lon1, lat2, lon2):\n" \
-                f"{state['bounding_box'].to_string_latlon()}\n"
-    user_msg = HumanMessage(content=bbox_text + state["messages"][0].content)
-
-    msgs = [user_msg]
+    msgs = state["alternative_history"] + [state["alternative_user_message"]]
     response = llm.invoke(msgs)
     return {"alternative_response": response}
 

--- a/utils/agent_utils.py
+++ b/utils/agent_utils.py
@@ -3,6 +3,7 @@ from langchain_ollama import ChatOllama
 from langchain_groq import ChatGroq
 from langchain_core.chat_history import InMemoryChatMessageHistory
 from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AnyMessage, AIMessage
 import streamlit as st
 
 LLM_OPTIONS = ['gpt-4o-mini', 'deepseek-r1-distill-llama-70b', 'llama3.2:3b-instruct-fp16', 'llama3.2']
@@ -14,14 +15,15 @@ LLM_PROVIDERS = {
 }
 DEFAULT_LLM = 'gpt-4o-mini'
 
-# TODO - Add session id key for history, if we will store all the conversations during a session
-def get_chat_history() -> InMemoryChatMessageHistory:
-    if f'chat_history' not in st.session_state:
-        st.session_state.chat_history = InMemoryChatMessageHistory()
-    return st.session_state.chat_history
+def get_chat_history(alternative: bool = False) -> InMemoryChatMessageHistory:
+    chat_key = f'chat_{st.session_state.thread_id}' if not alternative else f'chat_alt_{st.session_state.thread_id}'
+    if chat_key not in st.session_state:
+        st.session_state[chat_key] = InMemoryChatMessageHistory()
+    return st.session_state[chat_key]
 
 def clear_chat_history():
-    st.session_state.chat_history = InMemoryChatMessageHistory()
+    del st.session_state[f'chat_{st.session_state.thread_id}']
+    del st.session_state[f'chat_alt_{st.session_state.thread_id}']
     st.session_state.all_messages = {}
 
 def get_llm(model_name: str) -> BaseChatModel:
@@ -48,3 +50,19 @@ def get_llm(model_name: str) -> BaseChatModel:
                     max_retries=2,
                 )
     raise ValueError(f"Unknown LLM provider for model: {model_name}")
+
+def store_run_messages(messages: list[AnyMessage], alternative: bool = False):
+    """
+    Add all messages to the chat history and store each message in the session state.
+    """
+    get_chat_history(alternative=alternative).add_messages(messages)
+    for message in messages:
+        st.session_state.all_messages[message.id] = message
+
+def pair_response_messages(run_id: str, main: AIMessage, alternative: AIMessage):
+    """
+    Set the metadata for the main and alternative messages to link them together.
+    """
+    main.alternative_id = alternative.id
+    alternative.alternative_id = main.id
+    alternative.run_id = run_id

--- a/utils/streamlit_utils.py
+++ b/utils/streamlit_utils.py
@@ -24,8 +24,6 @@ def initialize_session_state():
         st.session_state.thread_id = uuid.uuid4()
     if "llm_choice" not in st.session_state:
         st.session_state.llm_choice = DEFAULT_LLM
-    if "chats" not in st.session_state:
-        st.session_state.chats = []
 
 def parse_drawing_geometry(map_data: dict, drawing_type: str) -> str:
     if not map_data["all_drawings"]:
@@ -252,8 +250,13 @@ def choose_preferred_message(main_msg, alt_msg, preferred_option):
 
 # TODO - preserve original message ids and other metadata after content swap?
 def swap_preferred_message(main_msg, alt_msg):
-    chat_history = get_chat_history()
+    chat_history = get_chat_history(alternative=False)
+    chat_alt_history = get_chat_history(alternative=True)
+
     for i, m in enumerate(chat_history.messages):
         if m.id == main_msg.id:
             chat_history.messages[i] = alt_msg
+    for i, m in enumerate(chat_alt_history.messages):
+        if m.id == alt_msg.id:
+            chat_alt_history.messages[i] = main_msg
     


### PR DESCRIPTION
- Accessing streamlit session state inside the running langgraph agent was overcomplicated and led to problems, for example when running nodes in parallel
- All streamlit data is handled before and after the graph runs
- Additional state variables were added to pass necessary data to the agent
- Chat history was added for alternate responses of LLM without tools for A/B testing